### PR TITLE
update psy version to '^0.7'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Shell extension Change Log
 2.0.1 under development
 -----------------------
 
-- no changes in this release.
+- Enh #10: Updated psy version
 
 
 2.0.0 November 22, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Shell extension Change Log
 2.0.1 under development
 -----------------------
 
-- Enh #10: Updated psy version
+- Enh #10: Updated psy version (kyle-mccarthy)
 
 
 2.0.0 November 22, 2016

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.0",
-        "psy/psysh": "0.7.*"
+        "psy/psysh": "^0.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #10 

Updated psy/psysh in composer to '^0.7' per the suggestion.  The old version is causing conflicts with some other packages I have installed making installing the shell impossible. 
