### PR TITLE
Fix #43: Version bump for symfony/var-dumper dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Shell extension Change Log
 2.0.7 under development
 -----------------------
 
-- no changes in this release.
+- Version bump for symfony/var-dumper dependency
 
 
 2.0.6 February 13, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 Shell extension Change Log
 2.0.7 under development
 -----------------------
 
-- Version bump for symfony/var-dumper dependency
+- Chg #43: Version bump for symfony/var-dumper dependency (Jiminald)
 
 
 2.0.6 February 13, 2025

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "yiisoft/yii2": "~2.0.0",
         "psy/psysh": "~0.9.3|~0.10.3|^0.11.0|^0.12.0",
-        "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0"
+        "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0|~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Added symfony/var-dumper versions of 6.0 and 7.0

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
