### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,28 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "yiisoft/*"
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    groups:
+      composer-dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Replicates the Dependabot grouping configuration from yiisoft/package-template so GitHub Actions updates are grouped into a single PR and Composer dependency updates are grouped into a single PR.